### PR TITLE
rm kub017 anti-affinity; mem issues reported to be fixed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,5 +41,5 @@ module "agent" {
   swarm_image         = "lsstsqre/jenkins-swarm-client:3.15-ldfc"
   agent_uid           = "48435"
   agent_gid           = "202"
-  node_blacklist      = ["lsst-kub017"]
+  node_blacklist      = ["bogus"]
 }


### PR DESCRIPTION
Due to tf 0.11 limitations, the list passed can not be completely empty, thus the "bogus" node name is being used.